### PR TITLE
feature/#6 add foundry to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,6 @@
+[default]
+src = 'contracts'
+out = 'build'
+libs = ['lib']
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+contract ContractTest is Test {
+    function setUp() public {}
+
+    function testExample() public {
+        assertTrue(true);
+    }
+}


### PR DESCRIPTION
Added foundry to repo to use forge for tests. Modified the default
source and build paths to match the current file structure. Forge uses a
git submodule to manage `lib/forge-std` which contains the test
dependancies
closes #6