### PR TITLE
Rewrote remaining pair tests. closes #11

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,5 @@ src = 'contracts'
 out = 'build'
 libs = ['lib']
 
+gas_reports = ["*"]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/UniswapV2PairTest.sol
+++ b/test/UniswapV2PairTest.sol
@@ -18,6 +18,14 @@ contract UniswapV2PairTest is Test {
     event Sync(uint112 reserve0, uint112 reserve1);
     event Mint(address indexed sender, uint amount0, uint amount1);
     event Burn(address indexed sender, uint amount0, uint amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
 
 
     function setUp() public {
@@ -26,7 +34,6 @@ contract UniswapV2PairTest is Test {
         token1 = getStubToken(expandTo18Decimals(10000));
 
         factory = new UniswapV2Factory(address(this));
-        factory.setFeeTo(address(this));
 
         address pairAddress = factory.createPair(address(token0), address(token1));
         pair = IUniswapV2Pair(pairAddress);
@@ -131,15 +138,214 @@ contract UniswapV2PairTest is Test {
         pair.swap(outputAmount, 0, address(this), '');
     }
 
+    function testSwapToken0() public {
+        uint256 token0Amount = expandTo18Decimals(5);
+        uint256 token1Amount = expandTo18Decimals(10);
+        addLiquidity(token0Amount, token1Amount);
+
+        uint256 swapAmount = expandTo18Decimals(1);
+        uint256 expectedOutputAmount = 1662497915624478906;
+
+        token0.transfer(address(pair), swapAmount);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(pair), address(this), expectedOutputAmount);
+        vm.expectEmit(false, false, false, true);
+        emit Sync(uint112(token0Amount + swapAmount), uint112(token1Amount - expectedOutputAmount));
+        vm.expectEmit(true, true, false, true);
+        emit Swap(address(this), swapAmount, 0, 0, expectedOutputAmount, address(this));
+
+        pair.swap(0, expectedOutputAmount, address(this), '');
+
+        (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast) = pair.getReserves();
+        assertEq(reserve0, token0Amount + swapAmount);
+        assertEq(reserve1, token1Amount - expectedOutputAmount);
+        assertEq(token0.balanceOf(address(pair)), token0Amount + swapAmount);
+        assertEq(token1.balanceOf(address(pair)), token1Amount - expectedOutputAmount);
+
+        uint256 totalSupplyToken0 = token0.totalSupply();
+        uint256 totalSupplyToken1 = token1.totalSupply();
+        assertEq(token0.balanceOf(address(this)), totalSupplyToken1 - token0Amount - swapAmount);
+        assertEq(token1.balanceOf(address(this)), totalSupplyToken1 - token1Amount + expectedOutputAmount);
+    }
+
+    function testSwapToken1() public {
+        uint256 token0Amount = expandTo18Decimals(5);
+        uint256 token1Amount = expandTo18Decimals(10);
+        addLiquidity(token0Amount, token1Amount);
+
+        uint256 swapAmount = expandTo18Decimals(1);
+        uint256 expectedOutputAmount = 453305446940074565;
+
+        token1.transfer(address(pair), swapAmount);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(pair), address(this), expectedOutputAmount);
+        vm.expectEmit(false, false, false, true);
+        emit Sync(uint112(token0Amount - expectedOutputAmount), uint112(token1Amount + swapAmount));
+        vm.expectEmit(true, true, false, true);
+        emit Swap(address(this), 0, swapAmount, expectedOutputAmount, 0, address(this));
+
+        pair.swap(expectedOutputAmount, 0, address(this), '');
+
+        (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast) = pair.getReserves();
+        assertEq(reserve0, token0Amount - expectedOutputAmount);
+        assertEq(reserve1, token1Amount + swapAmount);
+        assertEq(token0.balanceOf(address(pair)), token0Amount - expectedOutputAmount);
+        assertEq(token1.balanceOf(address(pair)), token1Amount + swapAmount);
+
+        uint256 totalSupplyToken0 = token0.totalSupply();
+        uint256 totalSupplyToken1 = token1.totalSupply();
+        assertEq(token0.balanceOf(address(this)), totalSupplyToken1 - token0Amount + expectedOutputAmount);
+        assertEq(token1.balanceOf(address(this)), totalSupplyToken1 - token1Amount - swapAmount);
+    }
+
+    function testSwapGas() public {
+        uint256 token0Amount = expandTo18Decimals(5);
+        uint256 token1Amount = expandTo18Decimals(10);
+        addLiquidity(token0Amount, token1Amount);
+
+        // ensure that setting price{0,1}CumulativeLast for the first time doesn't affect our gas math
+        mineBlock(2, block.timestamp + 1);
+        pair.sync();
+
+        uint256 swapAmount = expandTo18Decimals(1);
+        uint256 expectedOutputAmount = 453305446940074565;
+        token1.transfer(address(pair), swapAmount);
+        mineBlock(3, block.timestamp + 1);
+
+        uint256 gasStart = gasleft();
+        pair.swap(expectedOutputAmount, 0, address(this), '');
+        uint256 gasEnd = gasleft();
+        assertEq(gasStart - gasEnd, 20311, "<- yarn to forge <- 74721 <- update to 0.8.13 <- 73462");
+    }
+
+    function testBurn() public {
+        uint256 token0Amount = expandTo18Decimals(3);
+        uint256 token1Amount = expandTo18Decimals(3);
+        addLiquidity(token0Amount, token1Amount);
+
+        uint256 expectedLiquidity = expandTo18Decimals(3);
+        pair.transfer(address(pair), expectedLiquidity - MINIMUM_LIQUIDITY);
+
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(pair), address(0), expectedLiquidity - MINIMUM_LIQUIDITY);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(pair), address(this), token0Amount - 1000);
+        vm.expectEmit(true, true, false, true);
+        emit Transfer(address(pair), address(this), token1Amount - 1000);
+        vm.expectEmit(false, false, false, true);
+        emit Sync(1000, 1000);
+        vm.expectEmit(true, true, false, true);
+        emit Burn(address(this), token0Amount - 1000, token1Amount - 1000, address(this));
+
+        (uint outAmount0, uint outAmount1) = pair.burn(address(this));
+        assertEq(outAmount0, token0Amount - 1000);
+        assertEq(outAmount1, token1Amount - 1000);
+
+        assertEq(pair.balanceOf(address(this)), 0);
+        assertEq(pair.totalSupply(), MINIMUM_LIQUIDITY);
+        assertEq(token0.balanceOf(address(pair)), 1000);
+        assertEq(token1.balanceOf(address(pair)), 1000);
+        uint256 totalSupplyToken0 = token0.totalSupply();
+        uint256 totalSupplyToken1 = token1.totalSupply();
+        assertEq(token0.balanceOf(address(this)), totalSupplyToken0 - 1000);
+        assertEq(token1.balanceOf(address(this)), totalSupplyToken1 - 1000);
+    }
+
+    function testPrice01CumulativeLast() public {
+        uint256 token0Amount = expandTo18Decimals(3);
+        uint256 token1Amount = expandTo18Decimals(3);
+        addLiquidity(token0Amount, token1Amount);
+
+        (,, uint32 blockTimestamp1) = pair.getReserves();
+        mineBlock(2, blockTimestamp1 + 1);
+        pair.sync();
+        (uint256 initialPrice0, uint256 initialPrice1) = encodePrice(token0Amount, token1Amount);
+        assertEq(pair.price0CumulativeLast(), initialPrice0);
+        assertEq(pair.price1CumulativeLast(), initialPrice1);
+        (,, uint32 blockTimestamp2) = pair.getReserves();
+        assertEq(blockTimestamp2, blockTimestamp1 + 1);
+
+        uint256 swapAmount = expandTo18Decimals(3);
+        token0.transfer(address(pair), swapAmount);
+        mineBlock(3, blockTimestamp1 + 10);
+        // swap to a new price eagerly instead of syncing
+        pair.swap(0, expandTo18Decimals(1), address(this), ''); // make the price nice
+
+        assertEq(pair.price0CumulativeLast(), initialPrice0 * 10);
+        assertEq(pair.price1CumulativeLast(), initialPrice1 * 10);
+        (,, uint32 blockTimestamp3) = pair.getReserves();
+        assertEq(blockTimestamp3, blockTimestamp1 + 10);
+
+        mineBlock(4, blockTimestamp1 + 20);
+        pair.sync();
+
+        (uint256 newPrice0, uint256 newPrice1) = encodePrice(expandTo18Decimals(6), expandTo18Decimals(2));
+        assertEq(pair.price0CumulativeLast(), initialPrice0 * 10 + newPrice0 * 10);
+        assertEq(pair.price1CumulativeLast(), initialPrice1 * 10 + newPrice1 * 10);
+        (,, uint32 blockTimestamp4) = pair.getReserves();
+        assertEq(blockTimestamp4, blockTimestamp1 + 20);
+    }
+
+    function testFeeToOff() public {
+        uint256 token0Amount = expandTo18Decimals(1000);
+        uint256 token1Amount = expandTo18Decimals(1000);
+        addLiquidity(token0Amount, token1Amount);
+
+        uint256 swapAmount = expandTo18Decimals(1);
+        uint256 expectedOutputAmount = 996006981039903216;
+        token1.transfer(address(pair), swapAmount);
+        pair.swap(expectedOutputAmount, 0, address(this), '');
+
+        uint256 expectedLiquidity = expandTo18Decimals(1000);
+        pair.transfer(address(pair), expectedLiquidity - MINIMUM_LIQUIDITY);
+        pair.burn(address(this));
+        assertEq(pair.totalSupply(), MINIMUM_LIQUIDITY);
+    }
+
+    function testFeeToOn() public {
+        address other = address(2);
+        factory.setFeeTo(other);
+
+        uint256 token0Amount = expandTo18Decimals(1000);
+        uint256 token1Amount = expandTo18Decimals(1000);
+        addLiquidity(token0Amount, token1Amount);
+
+        uint256 swapAmount = expandTo18Decimals(1);
+        uint256 expectedOutputAmount = 996006981039903216;
+        token1.transfer(address(pair), swapAmount);
+        pair.swap(expectedOutputAmount, 0, address(this), '');
+
+        uint256 expectedLiquidity = expandTo18Decimals(1000);
+        pair.transfer(address(pair), expectedLiquidity - MINIMUM_LIQUIDITY);
+        pair.burn(address(this));
+        assertEq(pair.totalSupply(), MINIMUM_LIQUIDITY + 249750499251388);
+
+        // using 1000 here instead of the symbolic MINIMUM_LIQUIDITY because the amounts only happen to be equal...
+        // ...because the initial liquidity amounts were equal
+        assertEq(token0.balanceOf(address(pair)), 1000 + 249501683697445);
+        assertEq(token1.balanceOf(address(pair)), 1000 + 250000187312969);
+    }
+
     function addLiquidity(uint256 token0Amount, uint256 token1Amount) private {
         token0.transfer(address(pair), token0Amount);
         token1.transfer(address(pair), token1Amount);
         pair.mint(address(this));
+    }
 
+    function mineBlock(uint256 block, uint256 timestamp) private {
+        vm.roll(block);
+        vm.warp(timestamp);
     }
 
     function expandTo18Decimals(uint256 x) private pure returns (uint256) {
         return x * (10**18);
+    }
+
+    function encodePrice(uint256 reserve0, uint256 reserve1) private pure returns (uint256 price0, uint256 price1) {
+        price0 = reserve1 * (2 ** 112) / reserve0;
+        price1 = reserve0 * (2 ** 112) / reserve1;
     }
 
     function getStubToken(uint256 mintAmount_) private returns (IERC20) {
@@ -163,21 +369,17 @@ contract StubERC20 is IERC20 {
 
     function name() public view virtual override returns (string memory) {
         revert("name not used for tests.");
-        return "";
     }
 
     function symbol() public view virtual override returns (string memory) {
         revert("symbol not used for tests.");
-        return "";
     }
 
     function decimals() public view virtual override returns (uint8) {
         revert("decimals not used for tests.");
-        return 0;
     }
 
     function totalSupply() public view virtual override returns (uint256) {
-        revert("totalSupply not used for tests.");
         return _totalSupply;
     }
 
@@ -196,12 +398,10 @@ contract StubERC20 is IERC20 {
 
     function allowance(address owner, address spender) public view virtual override returns (uint256) {
         revert("allowance not used for tests.");
-        return 0;
     }
 
     function approve(address spender, uint256 amount) public virtual override returns (bool) {
         revert("approve not used for tests.");
-        return true;
     }
 
     function transferFrom(


### PR DESCRIPTION
Finished writing remaining pair tests. Did not delete current typescript
tests. Gas tests for swap did not come anywhere close to previous test
numbers. I did look at some of the gas reports available with foundry
and am assuming the difference in forge tests, the gas is measured as
additional gas added by swap transaction, but not what a swap would cost
as a standalone transaction. Clearly I need to learn more about gas.

Gas changes are described in test:
```
        assertEq(gasStart - gasEnd, 20311, "<- yarn to forge <- 74721 <- update to 0.8.13 <- 73462");
```

Gas report seems to match assertion.
```
$ forge test --gas-report
...
╭────────────────────────┬─────────────────┬────────┬────────┬────────┬─────────╮
│ UniswapV2Pair contract ┆                 ┆        ┆        ┆        ┆         │
╞════════════════════════╪═════════════════╪════════╪════════╪════════╪═════════╡
│ Deployment Cost        ┆ Deployment Size ┆        ┆        ┆        ┆         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ 1849143                ┆ 9167            ┆        ┆        ┆        ┆         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ Function Name          ┆ min             ┆ avg    ┆ median ┆ max    ┆ # calls │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ balanceOf              ┆ 581             ┆ 581    ┆ 581    ┆ 581    ┆ 2       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ burn                   ┆ 20445           ┆ 37467  ┆ 20445  ┆ 71513  ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ getReserves            ┆ 526             ┆ 526    ┆ 526    ┆ 526    ┆ 7       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ initialize             ┆ 44900           ┆ 44900  ┆ 44900  ┆ 44900  ┆ 19      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ mint                   ┆ 133174          ┆ 134710 ┆ 133666 ┆ 151297 ┆ 19      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ price0CumulativeLast   ┆ 384             ┆ 384    ┆ 384    ┆ 384    ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ price1CumulativeLast   ┆ 406             ┆ 406    ┆ 406    ┆ 406    ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ swap                   ┆ 10489           ┆ 13440  ┆ 15241  ┆ 16892  ┆ 28      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ sync                   ┆ 6264            ┆ 21436  ┆ 7576   ┆ 50469  ┆ 3       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ totalSupply            ┆ 429             ┆ 429    ┆ 429    ┆ 429    ┆ 4       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
│ transfer               ┆ 20260           ┆ 20260  ┆ 20260  ┆ 20260  ┆ 3       │
╰────────────────────────┴─────────────────┴────────┴────────┴────────┴─────────╯
```